### PR TITLE
Force arrow callbacks

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,7 @@
 			"error",
 			"tab"
 		],
-		"no-unused-vars": "warn"
+		"no-unused-vars": "warn",
+		"prefer-arrow-callback": "error"
 	}
 }

--- a/auth.js
+++ b/auth.js
@@ -102,7 +102,7 @@ app.post("/register", (req, res) => {
 	});
 });
 
-var authMid = function (req, res, next) {
+var authMid = (req, res, next) => {
 	logger.reqInfo(req);
 
 	if (!req.headers.authorization) {

--- a/auth.js
+++ b/auth.js
@@ -20,7 +20,7 @@ class User {
 
 	static insert(newTask, result) {
 		db.GetConnection((connection) => {
-			connection.query("INSERT INTO users SET ?", newTask, function (err, res) {
+			connection.query("INSERT INTO users SET ?", newTask, (err, res) => {
 				if (err) {
 					logger.error("error: " + err);
 					result(err, null);
@@ -33,7 +33,7 @@ class User {
 
 	static tryLogin(email, passwordHash, result) {
 		db.GetConnection((connection) => {
-			connection.query("SELECT * FROM users WHERE email = ? AND password = ?", [email, passwordHash], function (err, res) {
+			connection.query("SELECT * FROM users WHERE email = ? AND password = ?", [email, passwordHash], (err, res) => {
 				if (err) {
 					logger.error("error: " + err);
 					result(err, null);

--- a/db.js
+++ b/db.js
@@ -9,7 +9,7 @@ var mysql_pool = mysql.createPool({
 });
 
 function GetConnection(toDo) {
-	mysql_pool.getConnection(function (err, connection) {
+	mysql_pool.getConnection((err, connection) => {
 		if (err) {
 			console.log(" Error getting mysql_pool connection: " + err);
 			throw err;

--- a/element.js
+++ b/element.js
@@ -14,7 +14,7 @@ class User {
 
 	static insert(newTask, result) {
 		db.GetConnection((connection) => {
-			connection.query("INSERT INTO users SET ?", newTask, function (err, res) {
+			connection.query("INSERT INTO users SET ?", newTask, (err, res) => {
 				if (err) {
 					logger.error("error: " + err);
 					result(err, null);
@@ -27,7 +27,7 @@ class User {
 
 	static GetAllElemets(result) {
 		db.GetConnection((connection) => {
-			connection.query("SELECT * FROM elements", [], function (err, res) {
+			connection.query("SELECT * FROM elements", [], (err, res) => {
 				if (err) {
 					logger.error("error: " + err);
 					result(err, null);

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ app.use(require("./auth").app);
 app.use(require("./notifications").app);
 app.use(require("./element").app);
 
-app.all("/*", function (req, res, next) {
+app.all("/*", (req, res, next) => {
 	logger.error(req.method + " " + req.originalUrl, req);
 	res.status(400);
 	return res.send("not implemented yet sorry");

--- a/notifications.js
+++ b/notifications.js
@@ -11,7 +11,7 @@ app.ws("/notifications", (ws, req) => {
 
 // Let all dashboard clients know.
 function NotifyDashboard(data) {
-	expressWs.getWss("/notifications").clients.forEach(function each(client) {
+	expressWs.getWss("/notifications").clients.forEach((client) => {
 		if (client.readyState === WebSocket.OPEN) {
 			client.send(data);
 		}


### PR DESCRIPTION
Arrow callbacks are much more easier to read, and can take up much less space.

**Notice:** I've changed 
```js
expressWs.getWss("/notifications").clients.forEach(function each(client) {
```
to
 ```js
expressWs.getWss("/notifications").clients.forEach((client) => {
```
which might cause errors, since i've removed the each() function. 

